### PR TITLE
Changed VideoSource from abstract class to interface

### DIFF
--- a/DesktopStreamerDemo/ScreenVideoSource.cs
+++ b/DesktopStreamerDemo/ScreenVideoSource.cs
@@ -23,7 +23,7 @@ namespace DesktopStreamerDemo
         private Bitmap _previewImage = null;
         private bool _updatePreview = true;
 
-        public override event EventHandler<FrameCapturedEventArgs> FrameCaptured;
+        public event EventHandler<FrameCapturedEventArgs> FrameCaptured;
 
         public ScreenVideoSource(Screen screen, int screenId)
         {
@@ -33,8 +33,8 @@ namespace DesktopStreamerDemo
             _updateTimer.Elapsed += _updateTimer_Elapsed;
         }
 
-        public override void StartCapture() => _updateTimer.Start();
-        public override void StopCapture() => _updateTimer.Stop();
+        public void StartCapture() => _updateTimer.Start();
+        public void StopCapture() => _updateTimer.Stop();
 
         public Image QueryPreviewImage()
         {

--- a/LibMJPEGServer/Sources/TestVideoSource.cs
+++ b/LibMJPEGServer/Sources/TestVideoSource.cs
@@ -16,7 +16,7 @@ namespace LibMJPEGServer.Sources
         private Image _testFrame = new Bitmap(1280, 720);
         private Graphics _graphics;
 
-        public override event EventHandler<FrameCapturedEventArgs> FrameCaptured;
+        public event EventHandler<FrameCapturedEventArgs> FrameCaptured;
 
         public TestVideoSource()
         {
@@ -29,8 +29,8 @@ namespace LibMJPEGServer.Sources
             _updateTimer.Elapsed += OnElapsed;
         }
 
-        public override void StartCapture() => _updateTimer.Start();
-        public override void StopCapture() => _updateTimer.Stop();
+        public void StartCapture() => _updateTimer.Start();
+        public void StopCapture() => _updateTimer.Stop();
 
         private void OnElapsed(object sender, ElapsedEventArgs e)
         {

--- a/LibMJPEGServer/Sources/VideoSource.cs
+++ b/LibMJPEGServer/Sources/VideoSource.cs
@@ -7,11 +7,11 @@ using System.Threading.Tasks;
 
 namespace LibMJPEGServer.Sources
 {
-    public abstract class VideoSource
+    public interface VideoSource
     {
-        public abstract event EventHandler<FrameCapturedEventArgs> FrameCaptured;
+        event EventHandler<FrameCapturedEventArgs> FrameCaptured;
 
-        public abstract void StartCapture();
-        public abstract void StopCapture();
+        void StartCapture();
+        void StopCapture();
     }
 }

--- a/WebcamStreamerDemo/CameraVideoSource.cs
+++ b/WebcamStreamerDemo/CameraVideoSource.cs
@@ -16,7 +16,7 @@ namespace WebcamStreamerDemo
 
         private Mat _currentFrame = new Mat();
 
-        public override event EventHandler<FrameCapturedEventArgs> FrameCaptured;
+        public event EventHandler<FrameCapturedEventArgs> FrameCaptured;
 
         public CameraVideoSource()
         {
@@ -26,8 +26,8 @@ namespace WebcamStreamerDemo
             _capture.ImageGrabbed += OnImageGrabbed;
         }
 
-        public override void StartCapture() => _capture.Start();
-        public override void StopCapture() => _capture.Stop();
+        public void StartCapture() => _capture.Start();
+        public void StopCapture() => _capture.Stop();
 
         private void OnImageGrabbed(object sender, EventArgs e)
         {


### PR DESCRIPTION
Changing VideoSource to be implemented as an interface instead of an abstract class removes the unnecessary lock-out of VB.NET projects implementing VideoSource. For some reason MustOverride Events are not legitimate in VB.NET.

I see no downside in using a simple interface structure instead. The only downside is the change itself - even though adaptations would be trivial as seen in the DesktopStreamerDemo which merely required a removal of the "override" keyword.